### PR TITLE
Add missing application entrypoint

### DIFF
--- a/Vectorscope.py
+++ b/Vectorscope.py
@@ -393,6 +393,12 @@ class MainWindow(QMainWindow):
         self.timer.timeout.connect(self.update_scope)
         self.timer.start(16)  # 60 FPS for smooth animation
 
+    def closeEvent(self, event):
+        """Handle window close and clean up resources."""
+        self.audio.cleanup()
+        pygame.mixer.quit()
+        super().closeEvent(event)
+
     def create_top_controls(self, parent_layout):
         """Create top control panel"""
         top_group = QGroupBox("Audio Source")
@@ -701,3 +707,11 @@ class MainWindow(QMainWindow):
 
         painter.end()
         self.scope.setPixmap(QPixmap.fromImage(img))
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.exec()
+    pygame.quit()


### PR DESCRIPTION
## Summary
- add `closeEvent` to clean up audio resources on exit
- provide `__main__` entrypoint to launch the PyQt application

## Testing
- `python -m py_compile Vectorscope.py`


------
https://chatgpt.com/codex/tasks/task_e_688ad70b03b08325a0993eaba11d1367