### PR TITLE
Improve error messaging for audio dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# VectorScope
+
+This application displays a real-time vectorscope visualization. It relies on
+several Python packages:
+
+- `numpy`
+- `pygame`
+- `PyQt6`
+- `pydub` (optional, for loading MP3/FLAC/etc.)
+
+Install the dependencies using pip:
+
+```bash
+pip install numpy pygame PyQt6 pydub
+```
+
+If `pydub` is not installed, only uncompressed WAV files can be loaded. To start
+the application run:
+
+```bash
+python Vectorscope.py
+```

--- a/Vectorscope.py
+++ b/Vectorscope.py
@@ -18,7 +18,10 @@ try:
     PYDUB_AVAILABLE = True
 except ImportError:
     PYDUB_AVAILABLE = False
-    print("pydub not available - limited audio format support")
+    print(
+        "pydub not available - limited audio format support. "
+        "Install it with 'pip install pydub' for additional codecs."
+    )
 
 # === AUDIO PROCESSING THREAD ===
 class AudioLoaderThread(QThread):
@@ -87,7 +90,11 @@ class AudioLoaderThread(QThread):
                 audio_data = audio_array.reshape(-1, 2) / 32768.0
                 return {'data': audio_data, 'wav_path': self.file_path, 'temp': False}
         
-        raise Exception("Unsupported audio format")
+        if PYDUB_AVAILABLE:
+            raise Exception("Unsupported audio format")
+        raise Exception(
+            "Unsupported audio format. Install pydub for broader file support."
+        )
 
 # === SHADER-LIKE EFFECTS ===
 class ShaderEffects:


### PR DESCRIPTION
## Summary
- clarify pydub installation message
- explain missing pydub handling in loader
- document required dependencies

## Testing
- `python3 -m py_compile Vectorscope.py`

------
https://chatgpt.com/codex/tasks/task_e_688ad89b74048325a360a484d9af82d7