### PR TITLE
Fix missing QPainterPath import

### DIFF
--- a/Vectorscope.py
+++ b/Vectorscope.py
@@ -11,7 +11,16 @@ from PyQt6.QtWidgets import (
     QMainWindow, QGroupBox, QDoubleSpinBox
 )
 from PyQt6.QtCore import Qt, QTimer, QPointF, pyqtSignal, QThread
-from PyQt6.QtGui import QPixmap, QPainter, QColor, QPen, QImage, QRadialGradient, QBrush
+from PyQt6.QtGui import (
+    QPixmap,
+    QPainter,
+    QColor,
+    QPen,
+    QImage,
+    QRadialGradient,
+    QBrush,
+    QPainterPath,
+)
 
 try:
     from pydub import AudioSegment


### PR DESCRIPTION
## Summary
- fix missing `QPainterPath` import for bloom effect

## Testing
- `python Vectorscope.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688adba3530883258ca34e5a0fdd8cce